### PR TITLE
Feature/color management

### DIFF
--- a/src/sass/_settings.scss
+++ b/src/sass/_settings.scss
@@ -1,3 +1,5 @@
+@import 'functions/util';
+
 /// Susy settings
 /// @type Map
 $susy: (
@@ -48,13 +50,19 @@ $breakpoints: (
     large: 64em,
 ) !default;
 
-/// Default color settings
+/// Default color settings. Colors can be a single value
+/// or a map of colors acting like a color palette.
 ///
 /// @type Map
 $colors: (
     black: rgb(20, 20, 20),
     white: rgb(255, 255, 255),
-    blue: rgb(64, 120, 192),
+    blue: (
+        // Blue variants
+        aqua: rgb(127, 219, 255),
+        normal: rgb(0, 116, 217),
+        navy: rgb(0, 31, 63)
+    ),
 
     // ... moar colors ...
 ) !default;
@@ -117,7 +125,7 @@ $button-font-weight: normal !default;
 ///
 /// @type Color
 /// @group Button
-$button-font-color: map-get($colors, blue) !default;
+$button-font-color: map-deep-get($colors, blue, normal) !default;
 
 /// The default line height used on the buttons.
 ///
@@ -135,7 +143,7 @@ $button-background-color: map-get($colors, white) !default;
 ///
 /// @type mixed
 /// @group Button
-$button-border: 1px solid map-get($colors, blue) !default;
+$button-border: 1px solid map-deep-get($colors, blue, normal) !default;
 
 /// The default button padding.
 ///

--- a/src/sass/functions/_color.scss
+++ b/src/sass/functions/_color.scss
@@ -23,3 +23,27 @@
     @error "Unknown color `#{$color}`!";
     @return null;
 }
+
+/// Create a map of available colors.
+///
+/// @function  color-palette
+/// @prop      {String}  $separator
+/// @return    {Map}
+@function color-palette($separator: '-') {
+    $palette: ();
+
+    @each $name, $color in $colors {
+
+        // If the color is a map, then we need to loop over it
+        // before adding it to our palette of colors.
+        @if type-of($color) == map {
+            @each $map-name, $map-color in $color {
+                $palette: map-merge($palette, ("#{$name}#{$separator}#{$map-name}": $map-color));
+            }
+        } @else {
+            $palette: map-merge($palette, ($name: $color));
+        }
+    }
+
+    @return $palette;
+}

--- a/src/sass/functions/_color.scss
+++ b/src/sass/functions/_color.scss
@@ -1,8 +1,12 @@
-@function color-get($color) {
-    @if (map-has-key($colors, $color)) {
+@function color-get($color, $variant: false) {
+    @if $variant and type-of(map-get($colors, $color)) == map {
+        @return map-get(color-get($color), $variant);
+    }
+
+    @if map-has-key($colors, $color) {
         @return map-get($colors, $color);
     }
 
-    @warn "Unknown color `#{$color}`!";
+    @error "Unknown color `#{$color}`!";
     @return null;
 }

--- a/src/sass/functions/_color.scss
+++ b/src/sass/functions/_color.scss
@@ -1,12 +1,25 @@
+/// Get a color from the $colors variable found in the _settings.scss file.
+/// Color variants can be given when set in the $colors variable.
+///
+/// @function  color-get
+/// @prop      {Color}
+/// @prop      {Boolean}
+/// @return    {Color}
 @function color-get($color, $variant: false) {
+
+    // When a variant is given and the variant can be found in
+    // the $colors map then we'll try to retreive that color.
     @if $variant and type-of(map-get($colors, $color)) == map {
         @return map-get(color-get($color), $variant);
     }
 
+    // If the color is found in the $colors map or in
+    // the varient colors map then we'll return it.
     @if map-has-key($colors, $color) {
         @return map-get($colors, $color);
     }
 
+    // Error or when no color is given.
     @error "Unknown color `#{$color}`!";
     @return null;
 }

--- a/src/sass/functions/_util.scss
+++ b/src/sass/functions/_util.scss
@@ -23,3 +23,17 @@
 
     @return $str;
 }
+
+/// Map deep get
+///
+/// @function  map-deep-get
+/// @param     {Map}      $map
+/// @param     {Arglist}  $keys
+/// @return    {*}
+@function map-deep-get($map, $keys...) {
+    @each $key in $keys {
+        $map: map-get($map, $key);
+    }
+    
+    @return $map;
+}


### PR DESCRIPTION
The $colors map in the _settings.scss file can be a flat map of colors or a palette of colors like so:

```
$colors: (
    black: rgb(20, 20, 20),
    white: rgb(255, 255, 255),
    blue: (
        // Blue variants
        aqua: rgb(127, 219, 255),
        normal: rgb(0, 116, 217),
        navy: rgb(0, 31, 63)
    )
) !default;
```

So just looping over the $colors map will not yield the correct class names and/or colors so you'll need to use the color-palette() function to create 'palette-colors' like so:

```
@each $name, $color in color-palette() {
  .button-#{$name} {
    color: $color;
  }
}
```

Also the `color-get()` function can no receive variants:

```
.button {
  color: color-get(blue, aqua);
}
```
