### PR TITLE
Add Check if the social share network exists

### DIFF
--- a/src/js/lib/Social/Share.js
+++ b/src/js/lib/Social/Share.js
@@ -59,6 +59,9 @@ export default class Share {
     onClick(element) {
         const network = this.networks[element.getAttribute(this.selector)];
 
-        Window.open(network.url);
+        if (network) {
+            Window.open(network.url);
+        }
+        
     }
 }


### PR DESCRIPTION
When a data-social tag is clicked, but the network is not bound, an error occurs:

Uncaught TypeError: Cannot read property 'url' of undefined(…)

Fixed the error by checking if the network actually exists