### PR TITLE
Fixed the missing $current-separator variable error.

### DIFF
--- a/src/sass/functions/_color.scss
+++ b/src/sass/functions/_color.scss
@@ -38,6 +38,8 @@
         // before adding it to our palette of colors.
         @if type-of($color) == map {
             @each $map-name, $map-color in $color {
+                
+                $current-separator: $separator;
 
                 // If the default key is found then we can safely
                 // unset the map-name and separator values.


### PR DESCRIPTION
Added the $current-separator variable that will get overridden when _default is used on the $color map